### PR TITLE
fix problem with events defaulting to invite_only, maybe.

### DIFF
--- a/app/services/eventbrite_service.rb
+++ b/app/services/eventbrite_service.rb
@@ -124,6 +124,7 @@ private
         'capacity' => event.capacity,
         'listed' => true,
         'shareable' => true,
+        'invite_only' => false,
         'organizer_id' => Rails.configuration.eventbrite_organizer_id
       }
     }.to_json


### PR DESCRIPTION
Lately, I am seeing some events end up where only some people can search for them and signup. Think this might help.